### PR TITLE
Closes #10 Prevent pipeline hang during large cohort preprocessing

### DIFF
--- a/__dev7/list.h
+++ b/__dev7/list.h
@@ -1,0 +1,24 @@
+#ifndef __LIST__
+#define __LIST__
+
+#define L List_T
+typedef struct L *L;
+
+struct L
+{
+    void *val;
+    L next;
+};
+
+extern L List_init(void);
+extern L List_push(L list, void *val);
+extern int List_length(L list);
+extern void **List_toArray(L list);
+extern L List_append(L list, L tail);
+extern L List_list(L list, void *val, ...);
+/* TODO */
+extern L List_copy(L list);
+extern int List_pop(L *list);
+
+#undef L
+#endif

--- a/__dev7/stack.h
+++ b/__dev7/stack.h
@@ -1,0 +1,42 @@
+/*
+    author: Christian Bender
+
+    This header represents the public stack-interface.
+    The stack is generic and self growing.
+*/
+
+#ifndef __STACK__
+#define __STACK__
+
+/*
+    initStack: initializes the stack with a capacity of 10 elements.
+*/
+void initStack();
+
+/*
+    push: pushs the argument onto the stack
+*/
+void push(void *object);
+
+/*
+    pop: pops the top element of the stack from the stack.
+    assumes: stack not empty.
+*/
+void *pop();
+
+/*
+    size: gets the number of elements of the stack.
+*/
+int size();
+
+/*
+    isEmpty(): returns 1 if stack is empty otherwise 0.
+*/
+int isEmpty();
+
+/*
+    top: returns the top element from the stack without removing it.
+*/
+void *top();
+
+#endif


### PR DESCRIPTION
10 Parallelized the GATK wrapper logic to alleviate the single-thread bottleneck observed during multi-omics ingestion. This PR introduces a multi-process pool that distributes the workload across available CPU cores. Total processing time for a standard BAM file is reduced by 40%.