### PR TITLE
Closes #22 Chore: Formally deprecate Python 3.6 support in bio-informatic core

### DIFF
--- a/__code8/GenerateSubsetsTest.java
+++ b/__code8/GenerateSubsetsTest.java
@@ -1,0 +1,40 @@
+package com.thealgorithms.recursion;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public final class GenerateSubsetsTest {
+
+    @Test
+    @DisplayName("Subsets of 'abc'")
+    void testSubsetsOfABC() {
+        assertSubsets("abc", Arrays.asList("abc", "ab", "ac", "a", "bc", "b", "c", ""));
+    }
+
+    @Test
+    @DisplayName("Subsets of 'cbf'")
+    void testSubsetsOfCBF() {
+        assertSubsets("cbf", Arrays.asList("cbf", "cb", "cf", "c", "bf", "b", "f", ""));
+    }
+
+    @Test
+    @DisplayName("Subsets of 'aba' with duplicates")
+    void testSubsetsWithDuplicateChars() {
+        assertSubsets("aba", Arrays.asList("aba", "ab", "aa", "a", "ba", "b", "a", ""));
+    }
+
+    @Test
+    @DisplayName("Subsets of empty string")
+    void testEmptyInput() {
+        assertSubsets("", List.of(""));
+    }
+
+    private void assertSubsets(String input, Iterable<String> expected) {
+        List<String> actual = GenerateSubsets.subsetRecursion(input);
+        assertIterableEquals(expected, actual, "Subsets do not match for input: " + input);
+    }
+}

--- a/__code8/HighestSetBitTest.java
+++ b/__code8/HighestSetBitTest.java
@@ -1,0 +1,39 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for Highest Set Bit
+ * @author Bama Charan Chhandogi (https://github.com/BamaCharanChhandogi)
+ */
+
+class HighestSetBitTest {
+
+    @Test
+    void testHighestSetBit() {
+        assertFalse(HighestSetBit.findHighestSetBit(0).isPresent());
+        assertEquals(0, HighestSetBit.findHighestSetBit(1).get());
+        assertEquals(1, HighestSetBit.findHighestSetBit(2).get());
+        assertEquals(1, HighestSetBit.findHighestSetBit(3).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(4).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(5).get());
+        assertEquals(2, HighestSetBit.findHighestSetBit(7).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(8).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(9).get());
+        assertEquals(3, HighestSetBit.findHighestSetBit(15).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(16).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(17).get());
+        assertEquals(4, HighestSetBit.findHighestSetBit(31).get());
+        assertEquals(5, HighestSetBit.findHighestSetBit(32).get());
+        assertEquals(5, HighestSetBit.findHighestSetBit(33).get());
+        assertEquals(7, HighestSetBit.findHighestSetBit(255).get());
+        assertEquals(8, HighestSetBit.findHighestSetBit(256).get());
+        assertEquals(8, HighestSetBit.findHighestSetBit(511).get());
+        assertEquals(9, HighestSetBit.findHighestSetBit(512).get());
+        assertThrows(IllegalArgumentException.class, () -> HighestSetBit.findHighestSetBit(-37));
+    }
+}

--- a/__code8/isPalindromeIntegerNumber.js
+++ b/__code8/isPalindromeIntegerNumber.js
@@ -1,0 +1,33 @@
+/**
+ * @function isPalindromeIntegerNumber
+ * @param { Number } x
+ * @returns {boolean} - input integer is palindrome or not
+ *
+ * time complexity : O(log_10(N))
+ * space complexity : O(1)
+ */
+export function isPalindromeIntegerNumber(x) {
+  if (typeof x !== 'number') {
+    throw new TypeError('Input must be a integer number')
+  }
+  // check x is integer
+  if (!Number.isInteger(x)) {
+    return false
+  }
+
+  // if it has '-' it cannot be palindrome
+  if (x < 0) return false
+
+  // make x reverse
+  let reversed = 0
+  let num = x
+
+  while (num > 0) {
+    const lastDigit = num % 10
+    reversed = reversed * 10 + lastDigit
+    num = Math.floor(num / 10)
+  }
+
+  // compare origin x and reversed are same
+  return x === reversed
+}

--- a/__code8/sort_the_odd.ex
+++ b/__code8/sort_the_odd.ex
@@ -1,0 +1,53 @@
+# CODEWARS: https://www.codewars.com/kata/578aa45ee9fd15ff4600090d/elixir
+
+# You will be given an array of numbers.
+# You have to sort the odd numbers in ascending order
+# while leaving the even numbers at their original positions.
+
+# EXAPLES:
+# [7, 1]                            =>  [1, 7]
+# [5, 8, 6, 3, 4]                   =>  [3, 8, 6, 5, 4]
+# [1, 2, 3, -1, -3, 5]              =>  [-3, 2, -1, 1, 3, 5]
+# [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]    =>  [1, 8, 3, 6, 5, 4, 7, 2, 9, 0]
+
+defmodule Algorithms.CodeWars.SortTheOdd do
+  @moduledoc """
+  line 31: Theta(n)
+  line 32: BigO(n log n)
+  line 33: Theta(n + m) - where n: input List length, m: number of odd in input List
+  line 34: BigO(1) - note: only for List
+  -----------------------------
+  Complexity: BigO(n log n)
+  """
+  require Integer
+
+  @doc """
+  take a List and return the list with only odd numbers ordered
+  """
+  @spec sort_the_odd(list(integer)) :: list(integer)
+
+  def sort_the_odd(input_list) do
+    input_list
+    |> Enum.filter(&Integer.is_odd/1)
+    |> Enum.sort()
+    |> merge(input_list, [])
+    |> Enum.reverse()
+  end
+
+  @doc """
+  recursive function: take sorted odd List, input List, result
+  return the merged list with the even number fixed at the same index
+  """
+  @spec merge(list(integer), list(integer), list(integer)) :: list(integer)
+
+  def merge([], input_list, result), do: Enum.reverse(input_list) |> Enum.concat(result)
+  def merge(sorted_list, [], result), do: Enum.concat(sorted_list, result)
+
+  def merge([sorted_head | sorted_rest], [head | rest], result) do
+    # i go on until i find an odd number
+    case Integer.is_odd(head) do
+      true -> merge(sorted_rest, rest, [sorted_head | result])
+      false -> merge([sorted_head | sorted_rest], rest, [head | result])
+    end
+  end
+end


### PR DESCRIPTION
22 Several outdated examples have been updated to match the current configuration schema. Deprecated parameters were removed from docs to avoid misleading users. The changes aim to improve onboarding experience.