### PR TITLE
Closes #76 Prevent wrong model version serving during container startup in CI/CD

### DIFF
--- a/__build4/055_shortest_path_Java.java
+++ b/__build4/055_shortest_path_Java.java
@@ -1,0 +1,197 @@
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Breadth-First Search (shortest path on an unweighted graph) — single-file Java program.
+ *
+ * Input format (flexible):
+ * - Each non-empty, non-comment line lists a node followed by its neighbors.
+ *   Delimiters: tabs / spaces / commas are all accepted.
+ *     A   B   F
+ *     B   A   C
+ * - Query lines start with '#', followed by source and target:
+ *     #  A  E
+ *   (You can include multiple query lines; each will be answered.)
+ *
+ * CLI examples:
+ *   javac BFSShortestPath.java && java BFSShortestPath graph.txt
+ *   java BFSShortestPath --from A --to E graph.txt
+ *   cat graph.txt | java BFSShortestPath -
+ *
+ * Notes:
+ * - Defaults to UNDIRECTED graph. To use directed edges add --directed.
+ * - If no query lines are present, you must provide --from and --to.
+ */
+public class BFSShortestPath {
+
+    private static final Pattern DELIMS = Pattern.compile("[,\\t ]+");
+
+    private static class Args {
+        boolean directed = false;
+        String input = "-"; // "-" means stdin
+        String src = null;
+        String dst = null;
+    }
+
+    private static Args parseArgs(String[] argv) {
+        Args a = new Args();
+        for (int i = 0; i < argv.length; i++) {
+            String t = argv[i];
+            switch (t) {
+                case "--directed":
+                    a.directed = true;
+                    break;
+                case "--from":
+                    if (i + 1 >= argv.length) die("Missing value after --from");
+                    a.src = argv[++i];
+                    break;
+                case "--to":
+                    if (i + 1 >= argv.length) die("Missing value after --to");
+                    a.dst = argv[++i];
+                    break;
+                default:
+                    if (a.input.equals("-")) a.input = t;
+                    else die("Unexpected argument: " + t);
+            }
+        }
+        return a;
+    }
+
+    private static void die(String msg) {
+        System.err.println("ERROR: " + msg);
+        System.exit(2);
+    }
+
+    private static List<String> readAllLines(String path) {
+        try {
+            if (path.equals("-")) {
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                List<String> lines = new ArrayList<>();
+                for (String line; (line = br.readLine()) != null; ) lines.add(line);
+                return lines;
+            } else {
+                return Files.readAllLines(Paths.get(path));
+            }
+        } catch (IOException e) {
+            die("Failed to read input (" + path + "): " + e.getMessage());
+            return Collections.emptyList(); // unreachable
+        }
+    }
+
+    private static class Parsed {
+        Map<String, Set<String>> graph = new HashMap<>();
+        List<String[]> queries = new ArrayList<>();
+    }
+
+    private static Parsed parseGraphAndQueries(List<String> lines, boolean directed) {
+        Parsed p = new Parsed();
+
+        for (String raw : lines) {
+            if (raw == null) continue;
+            String line = raw.trim();
+            if (line.isEmpty()) continue;
+
+            if (line.startsWith("#")) {
+                String rest = line.substring(1).trim();
+                if (!rest.isEmpty()) {
+                    String[] toks = DELIMS.split(rest);
+                    if (toks.length >= 2) {
+                        p.queries.add(new String[]{toks[0], toks[1]});
+                    }
+                }
+                continue;
+            }
+
+            String[] toks = DELIMS.split(line);
+            if (toks.length == 0) continue;
+
+            String u = toks[0];
+            ensureNode(p.graph, u);
+            for (int i = 1; i < toks.length; i++) {
+                String v = toks[i];
+                if (v.isEmpty()) continue;
+                ensureNode(p.graph, v);
+                p.graph.get(u).add(v);
+                if (!directed) p.graph.get(v).add(u);
+            }
+        }
+        return p;
+    }
+
+    private static void ensureNode(Map<String, Set<String>> g, String n) {
+        g.computeIfAbsent(n, k -> new LinkedHashSet<>());
+    }
+
+    /** Returns shortest path (src..dst) or null if none. */
+    public static List<String> bfsShortestPath(Map<String, Set<String>> g, String src, String dst) {
+        if (!g.containsKey(src) || !g.containsKey(dst)) return null;
+        if (src.equals(dst)) return Collections.singletonList(src);
+
+        Deque<String> q = new ArrayDeque<>();
+        q.add(src);
+
+        Set<String> seen = new HashSet<>();
+        seen.add(src);
+
+        Map<String, String> parent = new HashMap<>();
+
+        while (!q.isEmpty()) {
+            String u = q.removeFirst();
+            for (String v : g.getOrDefault(u, Collections.emptySet())) {
+                if (seen.contains(v)) continue;
+                seen.add(v);
+                parent.put(v, u);
+                if (v.equals(dst)) {
+                    return reconstruct(parent, src, dst);
+                }
+                q.addLast(v);
+            }
+        }
+        return null;
+    }
+
+    private static List<String> reconstruct(Map<String, String> parent, String src, String dst) {
+        List<String> path = new ArrayList<>();
+        String cur = dst;
+        while (cur != null) {
+            path.add(cur);
+            if (cur.equals(src)) break;
+            cur = parent.get(cur);
+        }
+        if (!path.get(path.size() - 1).equals(src)) return null; // disconnected
+        Collections.reverse(path);
+        return path;
+    }
+
+    private static String formatPath(List<String> path) {
+        return String.join(" -> ", path);
+    }
+
+    public static void main(String[] argv) {
+        Args args = parseArgs(argv);
+        List<String> lines = readAllLines(args.input);
+        Parsed parsed = parseGraphAndQueries(lines, args.directed);
+
+        List<String[]> queries = new ArrayList<>(parsed.queries);
+        if (queries.isEmpty()) {
+            if (args.src == null || args.dst == null) {
+                die("No queries in input and --from/--to not provided.");
+            }
+            queries.add(new String[]{args.src, args.dst});
+        }
+
+        for (String[] q : queries) {
+            String src = q[0], dst = q[1];
+            List<String> path = bfsShortestPath(parsed.graph, src, dst);
+            if (path == null) {
+                System.out.println("NO PATH: " + src + " -> " + dst);
+            } else {
+                int hops = path.size() - 1;
+                System.out.println("PATH (" + hops + " edges): " + formatPath(path));
+            }
+        }
+    }
+}
+

--- a/__build4/BM25InvertedIndexTest.java
+++ b/__build4/BM25InvertedIndexTest.java
@@ -1,0 +1,95 @@
+package com.thealgorithms.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test Cases for Inverted Index with BM25
+ * @author Prayas Kumar (https://github.com/prayas7102)
+ */
+
+class BM25InvertedIndexTest {
+
+    private static BM25InvertedIndex index;
+
+    @BeforeAll
+    static void setUp() {
+        index = new BM25InvertedIndex();
+        index.addMovie(1, "The Shawshank Redemption", 9.3, 1994, "Hope is a good thing. Maybe the best of things. And no good thing ever dies.");
+        index.addMovie(2, "The Godfather", 9.2, 1972, "I'm gonna make him an offer he can't refuse.");
+        index.addMovie(3, "The Dark Knight", 9.0, 2008, "You either die a hero or live long enough to see yourself become the villain.");
+        index.addMovie(4, "Pulp Fiction", 8.9, 1994, "You know what they call a Quarter Pounder with Cheese in Paris? They call it a Royale with Cheese.");
+        index.addMovie(5, "Good Will Hunting", 8.3, 1997, "Will Hunting is a genius and he has a good heart. The best of his abilities is yet to be explored.");
+        index.addMovie(6, "It's a Wonderful Life", 8.6, 1946, "Each man's life touches so many other lives. If he wasn't around, it would leave an awfully good hole.");
+        index.addMovie(7, "The Pursuit of Happyness", 8.0, 2006, "It was the pursuit of a better life, and a good opportunity to change things for the better.");
+        index.addMovie(8, "A Few Good Men", 7.7, 1992, "You can't handle the truth! This movie has a lot of good moments and intense drama.");
+    }
+
+    @Test
+    void testAddMovie() {
+        // Check that the index contains the correct number of movies
+        int moviesLength = index.getMoviesLength();
+        assertEquals(8, moviesLength);
+    }
+
+    @Test
+    void testSearchForTermFound() {
+        int expected = 1;
+        List<SearchResult> result = index.search("hope");
+        int actual = result.getFirst().getDocId();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testSearchRanking() {
+        // Perform search for the term "good"
+        List<SearchResult> results = index.search("good");
+        assertFalse(results.isEmpty());
+        for (SearchResult result : results) {
+            System.out.println(result);
+        }
+        // Validate the ranking based on the provided relevance scores
+        assertEquals(1, results.get(0).getDocId()); // The Shawshank Redemption should be ranked 1st
+        assertEquals(8, results.get(1).getDocId()); // A Few Good Men should be ranked 2nd
+        assertEquals(5, results.get(2).getDocId()); // Good Will Hunting should be ranked 3rd
+        assertEquals(7, results.get(3).getDocId()); // The Pursuit of Happyness should be ranked 4th
+        assertEquals(6, results.get(4).getDocId()); // It's a Wonderful Life should be ranked 5th
+
+        // Ensure the relevance scores are in descending order
+        for (int i = 0; i < results.size() - 1; i++) {
+            assertTrue(results.get(i).getRelevanceScore() > results.get(i + 1).getRelevanceScore());
+        }
+    }
+
+    @Test
+    void testSearchForTermNotFound() {
+        List<SearchResult> results = index.search("nonexistent");
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void testSearchForCommonTerm() {
+        List<SearchResult> results = index.search("the");
+        assertFalse(results.isEmpty());
+        assertTrue(results.size() > 1);
+    }
+
+    @Test
+    void testBM25ScoreCalculation() {
+        List<SearchResult> results = index.search("cheese");
+        assertEquals(1, results.size());
+        assertEquals(4, results.getFirst().docId); // Pulp Fiction should have the highest score
+    }
+
+    @Test
+    void testCaseInsensitivity() {
+        List<SearchResult> resultsLowerCase = index.search("hope");
+        List<SearchResult> resultsUpperCase = index.search("HOPE");
+        assertEquals(resultsLowerCase, resultsUpperCase);
+    }
+}

--- a/__build4/KMPTest.java
+++ b/__build4/KMPTest.java
@@ -1,0 +1,29 @@
+package com.thealgorithms.strings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class KMPTest {
+
+    @Test
+    public void testNullInputs() {
+        assertEquals(List.of(), KMP.kmpMatcher(null, "A"));
+        assertEquals(List.of(), KMP.kmpMatcher("A", null));
+        assertEquals(List.of(), KMP.kmpMatcher(null, null));
+    }
+
+    @Test
+    public void testKMPMatcher() {
+        assertEquals(List.of(0, 1), KMP.kmpMatcher("AAAAABAAABA", "AAAA"));
+        assertEquals(List.of(0, 3), KMP.kmpMatcher("ABCABC", "ABC"));
+        assertEquals(List.of(10), KMP.kmpMatcher("ABABDABACDABABCABAB", "ABABCABAB"));
+        assertEquals(List.of(), KMP.kmpMatcher("ABCDE", "FGH"));
+        assertEquals(List.of(), KMP.kmpMatcher("A", "AA"));
+        assertEquals(List.of(0, 1, 2), KMP.kmpMatcher("AAA", "A"));
+        assertEquals(List.of(0), KMP.kmpMatcher("A", "A"));
+        assertEquals(List.of(), KMP.kmpMatcher("", "A"));
+        assertEquals(List.of(), KMP.kmpMatcher("A", ""));
+    }
+}

--- a/__build4/elliptic_curve.rs
+++ b/__build4/elliptic_curve.rs
@@ -1,0 +1,405 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Neg, Sub};
+
+use crate::math::field::{Field, PrimeField};
+use crate::math::quadratic_residue::legendre_symbol;
+
+/// Elliptic curve defined by `y^2 = x^3 + Ax + B` over a prime field `F` of
+/// characteristic != 2, 3
+///
+/// The coefficients of the elliptic curve are the constant parameters `A` and `B`.
+///
+/// Points form an abelian group with the neutral element [`EllipticCurve::infinity`]. The points
+/// are represented via affine coordinates ([`EllipticCurve::new`]) except for the points
+/// at infinity ([`EllipticCurve::infinity`]).
+///
+/// # Example
+///
+/// ```
+/// use the_algorithms_rust::math::{EllipticCurve, PrimeField};
+/// type E = EllipticCurve<PrimeField<7>, 1, 0>;
+/// let P = E::new(0, 0).expect("not on curve E");
+/// assert_eq!(P + P, E::infinity());
+/// ```
+#[derive(Clone, Copy)]
+pub struct EllipticCurve<F, const A: i64, const B: i64> {
+    infinity: bool,
+    x: F,
+    y: F,
+}
+
+impl<F: Field, const A: i64, const B: i64> EllipticCurve<F, A, B> {
+    /// Point at infinity also the neutral element of the group
+    pub fn infinity() -> Self {
+        Self::check_invariants();
+        Self {
+            infinity: true,
+            x: F::ZERO,
+            y: F::ZERO,
+        }
+    }
+
+    /// Affine point
+    ///
+    ///
+    /// Return `None` if the coordinates are not on the curve
+    pub fn new(x: impl Into<F>, y: impl Into<F>) -> Option<Self> {
+        Self::check_invariants();
+        let x = x.into();
+        let y = y.into();
+        if Self::contains(x, y) {
+            Some(Self {
+                infinity: false,
+                x,
+                y,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Return `true` if this is the point at infinity
+    pub fn is_infinity(&self) -> bool {
+        self.infinity
+    }
+
+    /// The affine x-coordinate of the point
+    pub fn x(&self) -> &F {
+        &self.x
+    }
+
+    /// The affine y-coordinate of the point
+    pub fn y(&self) -> &F {
+        &self.y
+    }
+
+    /// The discrimant of the elliptic curve
+    pub const fn discriminant() -> i64 {
+        // Note: we can't return an element of F here, because it is not
+        // possible to declare a trait function as const (cf.
+        // <https://doc.rust-lang.org/error_codes/E0379.html>)
+        (-16 * (4 * A * A * A + 27 * B * B)) % (F::CHARACTERISTIC as i64)
+    }
+
+    fn contains(x: F, y: F) -> bool {
+        y * y == x * x * x + x.integer_mul(A) + F::ONE.integer_mul(B)
+    }
+
+    const fn check_invariants() {
+        assert!(F::CHARACTERISTIC != 2);
+        assert!(F::CHARACTERISTIC != 3);
+        assert!(Self::discriminant() != 0);
+    }
+}
+
+/// Elliptic curve methods over a prime field
+impl<const P: u64, const A: i64, const B: i64> EllipticCurve<PrimeField<P>, A, B> {
+    /// Naive calculation of points via enumeration
+    // TODO: Implement via generators
+    pub fn points() -> impl Iterator<Item = Self> {
+        std::iter::once(Self::infinity()).chain(
+            PrimeField::elements()
+                .flat_map(|x| PrimeField::elements().filter_map(move |y| Self::new(x, y))),
+        )
+    }
+
+    /// Number of points on the elliptic curve over `F`, that is, `#E(F)`
+    pub fn cardinality() -> usize {
+        // TODO: implement counting for big P
+        Self::cardinality_counted_legendre()
+    }
+
+    /// Number of points on the elliptic curve over `F`, that is, `#E(F)`
+    ///
+    /// We simply count the number of points for each x coordinate and sum them up.
+    /// For that, we first precompute the table of all squares in `F`.
+    ///
+    /// Time complexity: O(P) <br>
+    /// Space complexity: O(P)
+    ///
+    /// Only fast for small fields.
+    pub fn cardinality_counted_table() -> usize {
+        let squares: HashSet<_> = PrimeField::<P>::elements().map(|x| x * x).collect();
+        1 + PrimeField::elements()
+            .map(|x| {
+                let y_square = x * x * x + x.integer_mul(A) + PrimeField::from_integer(B);
+                if y_square == PrimeField::ZERO {
+                    1
+                } else if squares.contains(&y_square) {
+                    2
+                } else {
+                    0
+                }
+            })
+            .sum::<usize>()
+    }
+
+    /// Number of points on the elliptic curve over `F`, that is, `#E(F)`
+    ///
+    /// We count the number of points for each x coordinate by using the [Legendre symbol] _(X |
+    /// P)_:
+    ///
+    /// _1 + (x^3 + Ax + B | P),_
+    ///
+    /// The total number of points is then:
+    ///
+    /// _#E(F) = 1 + P + Σ_x (x^3 + Ax + B | P)_ for _x_ in _F_.
+    ///
+    /// Time complexity: O(P) <br>
+    /// Space complexity: O(1)
+    ///
+    /// Only fast for small fields.
+    ///
+    /// [Legendre symbol]: https://en.wikipedia.org/wiki/Legendre_symbol
+    pub fn cardinality_counted_legendre() -> usize {
+        let cardinality: i64 = 1
+            + P as i64
+            + PrimeField::<P>::elements()
+                .map(|x| {
+                    let y_square = x * x * x + x.integer_mul(A) + PrimeField::from_integer(B);
+                    let y_square_int = y_square.to_integer();
+                    legendre_symbol(y_square_int, P)
+                })
+                .sum::<i64>();
+        cardinality
+            .try_into()
+            .expect("invalid legendre cardinality")
+    }
+}
+
+/// Group law
+impl<F: Field, const A: i64, const B: i64> Add for EllipticCurve<F, A, B> {
+    type Output = Self;
+
+    fn add(self, p: Self) -> Self::Output {
+        if self.infinity {
+            p
+        } else if p.infinity {
+            self
+        } else if self.x == p.x && self.y == -p.y {
+            // mirrored
+            Self::infinity()
+        } else {
+            let slope = if self.x == p.x {
+                ((self.x * self.x).integer_mul(3) + F::from_integer(A)) / self.y.integer_mul(2)
+            } else {
+                (self.y - p.y) / (self.x - p.x)
+            };
+            let x = slope * slope - self.x - p.x;
+            let y = -self.y + slope * (self.x - x);
+            Self::new(x, y).expect("elliptic curve group law failed")
+        }
+    }
+}
+
+/// Inverse
+impl<F: Field, const A: i64, const B: i64> Neg for EllipticCurve<F, A, B> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        if self.infinity {
+            self
+        } else {
+            Self::new(self.x, -self.y).expect("elliptic curves are x-axis symmetric")
+        }
+    }
+}
+
+/// Difference
+impl<F: Field, const A: i64, const B: i64> Sub for EllipticCurve<F, A, B> {
+    type Output = Self;
+
+    fn sub(self, p: Self) -> Self::Output {
+        self + (-p)
+    }
+}
+
+/// Debug representation via projective coordinates
+impl<F: fmt::Debug, const A: i64, const B: i64> fmt::Debug for EllipticCurve<F, A, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.infinity {
+            f.write_str("(0:0:1)")
+        } else {
+            write!(f, "({:?}:{:?}:1)", self.x, self.y)
+        }
+    }
+}
+
+/// Equality of the elliptic curve points (short-circuit at infinity)
+impl<F: Field, const A: i64, const B: i64> PartialEq for EllipticCurve<F, A, B> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.infinity && other.infinity)
+            || (self.infinity == other.infinity && self.x == other.x && self.y == other.y)
+    }
+}
+
+impl<F: Field, const A: i64, const B: i64> Eq for EllipticCurve<F, A, B> {}
+
+impl<F: Field + Hash, const A: i64, const B: i64> Hash for EllipticCurve<F, A, B> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if self.infinity {
+            state.write_u8(1);
+            F::ZERO.hash(state);
+            F::ZERO.hash(state);
+        } else {
+            state.write_u8(0);
+            self.x.hash(state);
+            self.y.hash(state);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::time::Instant;
+
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_char_2_panic() {
+        EllipticCurve::<PrimeField<2>, -1, 1>::infinity();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_char_3_panic() {
+        EllipticCurve::<PrimeField<2>, -1, 1>::infinity();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_singular_panic() {
+        EllipticCurve::<PrimeField<5>, 0, 0>::infinity();
+    }
+
+    #[test]
+    fn e_5_1_0_group_table() {
+        type F = PrimeField<5>;
+        type E = EllipticCurve<F, 1, 0>;
+
+        assert_eq!(E::points().count(), 4);
+        let [a, b, c, d] = [
+            E::new(0, 0).unwrap(),
+            E::infinity(),
+            E::new(2, 0).unwrap(),
+            E::new(3, 0).unwrap(),
+        ];
+
+        assert_eq!(a + a, b);
+        assert_eq!(a + b, a);
+        assert_eq!(a + c, d);
+        assert_eq!(a + d, c);
+        assert_eq!(b + a, a);
+        assert_eq!(b + b, b);
+        assert_eq!(b + c, c);
+        assert_eq!(b + d, d);
+        assert_eq!(c + a, d);
+        assert_eq!(c + b, c);
+        assert_eq!(c + c, b);
+        assert_eq!(c + d, a);
+        assert_eq!(d + a, c);
+        assert_eq!(d + b, d);
+        assert_eq!(d + c, a);
+        assert_eq!(d + d, b);
+    }
+
+    #[test]
+    fn group_law() {
+        fn test<const P: u64>() {
+            type E<const P: u64> = EllipticCurve<PrimeField<P>, 1, 0>;
+
+            let o = E::<P>::infinity();
+            assert_eq!(-o, o);
+
+            let points: Vec<_> = E::points().collect();
+            for &p in &points {
+                assert_eq!(p + (-p), o); // inverse
+                assert_eq!((-p) + p, o); // inverse
+                assert_eq!(p - p, o); //inverse
+                assert_eq!(p + o, p); // neutral
+                assert_eq!(o + p, p); //neutral
+
+                for &q in &points {
+                    assert_eq!(p + q, q + p); // commutativity
+
+                    // associativity
+                    for &s in &points {
+                        assert_eq!((p + q) + s, p + (q + s));
+                    }
+                }
+            }
+        }
+        test::<5>();
+        test::<7>();
+        test::<11>();
+        test::<13>();
+        test::<17>();
+        test::<19>();
+        test::<23>();
+    }
+
+    #[test]
+    fn cardinality() {
+        fn test<const P: u64>(expected: usize) {
+            type E<const P: u64> = EllipticCurve<PrimeField<P>, 1, 0>;
+            assert_eq!(E::<P>::cardinality(), expected);
+            assert_eq!(E::<P>::cardinality_counted_table(), expected);
+            assert_eq!(E::<P>::cardinality_counted_legendre(), expected);
+        }
+        test::<5>(4);
+        test::<7>(8);
+        test::<11>(12);
+        test::<13>(20);
+        test::<17>(16);
+        test::<19>(20);
+        test::<23>(24);
+    }
+
+    #[test]
+    #[ignore = "slow test for measuring time"]
+    fn cardinality_perf() {
+        const P: u64 = 1000003;
+        type E = EllipticCurve<PrimeField<P>, 1, 0>;
+        const EXPECTED: usize = 1000004;
+
+        let now = Instant::now();
+        assert_eq!(E::cardinality_counted_table(), EXPECTED);
+        println!("cardinality_counted_table    : {:?}", now.elapsed());
+        let now = Instant::now();
+        assert_eq!(E::cardinality_counted_legendre(), EXPECTED);
+        println!("cardinality_counted_legendre : {:?}", now.elapsed());
+    }
+
+    #[test]
+    #[ignore = "slow test showing that cadinality is not yet feasible to compute for a large prime"]
+    fn cardinality_large_prime() {
+        const P: u64 = 2_u64.pow(63) - 25; // largest prime fitting into i64
+        type E = EllipticCurve<PrimeField<P>, 1, 0>;
+        const EXPECTED: usize = 9223372041295506260;
+
+        let now = Instant::now();
+        assert_eq!(E::cardinality(), EXPECTED);
+        println!("cardinality: {:?}", now.elapsed());
+    }
+
+    #[test]
+    fn test_points() {
+        type F = PrimeField<5>;
+        type E = EllipticCurve<F, 1, 0>;
+
+        let points: HashSet<_> = E::points().collect();
+        let expected: HashSet<_> = [
+            E::infinity(),
+            E::new(0, 0).unwrap(),
+            E::new(2, 0).unwrap(),
+            E::new(3, 0).unwrap(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(points, expected);
+    }
+}

--- a/__build4/isPalindrome.m
+++ b/__build4/isPalindrome.m
@@ -1,0 +1,17 @@
+function y = isPalindrome(inputWord)
+    % Return 1 if input string is a palindrome; 0 otherwise. 
+    
+    % Gets the length of the input word.
+    inputLength = length(inputWord);
+
+    % Number of pairs to compare.
+    lastIndex = floor( inputLength / 2);
+    y=1;
+    % for every pair of letters in the word check if they match
+    for i = 1 : lastIndex
+        if inputWord(i) ~= inputWord(end + (1 - i))
+            y = 0;
+        end
+    end
+    
+end

--- a/__build4/print_reverse.py
+++ b/__build4/print_reverse.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+
+@dataclass
+class Node:
+    data: int
+    next_node: Node | None = None
+
+
+class LinkedList:
+    """A class to represent a Linked List.
+    Use a tail pointer to speed up the append() operation.
+    """
+
+    def __init__(self) -> None:
+        """Initialize a LinkedList with the head node set to None.
+        >>> linked_list = LinkedList()
+        >>> (linked_list.head, linked_list.tail)
+        (None, None)
+        """
+        self.head: Node | None = None
+        self.tail: Node | None = None  # Speeds up the append() operation
+
+    def __iter__(self) -> Iterator[int]:
+        """Iterate the LinkedList yielding each Node's data.
+        >>> linked_list = LinkedList()
+        >>> items = (1, 2, 3, 4, 5)
+        >>> linked_list.extend(items)
+        >>> tuple(linked_list) == items
+        True
+        """
+        node = self.head
+        while node:
+            yield node.data
+            node = node.next_node
+
+    def __repr__(self) -> str:
+        """Returns a string representation of the LinkedList.
+        >>> linked_list = LinkedList()
+        >>> str(linked_list)
+        ''
+        >>> linked_list.append(1)
+        >>> str(linked_list)
+        '1'
+        >>> linked_list.extend([2, 3, 4, 5])
+        >>> str(linked_list)
+        '1 -> 2 -> 3 -> 4 -> 5'
+        """
+        return " -> ".join([str(data) for data in self])
+
+    def append(self, data: int) -> None:
+        """Appends a new node with the given data to the end of the LinkedList.
+        >>> linked_list = LinkedList()
+        >>> str(linked_list)
+        ''
+        >>> linked_list.append(1)
+        >>> str(linked_list)
+        '1'
+        >>> linked_list.append(2)
+        >>> str(linked_list)
+        '1 -> 2'
+        """
+        if self.tail:
+            self.tail.next_node = self.tail = Node(data)
+        else:
+            self.head = self.tail = Node(data)
+
+    def extend(self, items: Iterable[int]) -> None:
+        """Appends each item to the end of the LinkedList.
+        >>> linked_list = LinkedList()
+        >>> linked_list.extend([])
+        >>> str(linked_list)
+        ''
+        >>> linked_list.extend([1, 2])
+        >>> str(linked_list)
+        '1 -> 2'
+        >>> linked_list.extend([3,4])
+        >>> str(linked_list)
+        '1 -> 2 -> 3 -> 4'
+        """
+        for item in items:
+            self.append(item)
+
+
+def make_linked_list(elements_list: Iterable[int]) -> LinkedList:
+    """Creates a Linked List from the elements of the given sequence
+    (list/tuple) and returns the head of the Linked List.
+    >>> make_linked_list([])
+    Traceback (most recent call last):
+        ...
+    Exception: The Elements List is empty
+    >>> make_linked_list([7])
+    7
+    >>> make_linked_list(['abc'])
+    abc
+    >>> make_linked_list([7, 25])
+    7 -> 25
+    """
+    if not elements_list:
+        raise Exception("The Elements List is empty")
+
+    linked_list = LinkedList()
+    linked_list.extend(elements_list)
+    return linked_list
+
+
+def in_reverse(linked_list: LinkedList) -> str:
+    """Prints the elements of the given Linked List in reverse order
+    >>> in_reverse(LinkedList())
+    ''
+    >>> in_reverse(make_linked_list([69, 88, 73]))
+    '73 <- 88 <- 69'
+    """
+    return " <- ".join(str(line) for line in reversed(tuple(linked_list)))
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()
+    linked_list = make_linked_list((14, 52, 14, 12, 43))
+    print(f"Linked List:  {linked_list}")
+    print(f"Reverse List: {in_reverse(linked_list)}")

--- a/__build4/subset_sum.rs
+++ b/__build4/subset_sum.rs
@@ -1,0 +1,81 @@
+//! This module provides a solution to the subset sum problem using dynamic programming.
+//!
+//! # Complexity
+//! - Time complexity: O(n * sum) where n is array length and sum is the target sum
+//! - Space complexity: O(n * sum) for the DP table
+/// Determines if there exists a subset of the given array that sums to the target value.
+/// Uses dynamic programming to solve the subset sum problem.
+///
+/// # Arguments
+/// * `arr` - A slice of integers representing the input array.
+/// * `required_sum` - The target sum to check for.
+///
+/// # Returns
+/// * `bool` - A boolean indicating whether a subset exists that sums to the target.
+pub fn is_sum_subset(arr: &[i32], required_sum: i32) -> bool {
+    let n = arr.len();
+
+    // Handle edge case where required sum is 0 (empty subset always sums to 0)
+    if required_sum == 0 {
+        return true;
+    }
+
+    // Handle edge case where array is empty but required sum is positive
+    if n == 0 && required_sum > 0 {
+        return false;
+    }
+    // dp[i][j] stores whether sum j can be achieved using first i elements
+    let mut dp = vec![vec![false; required_sum as usize + 1]; n + 1];
+    // Base case: sum 0 can always be achieved with any number of elements (empty subset)
+    for i in 0..=n {
+        dp[i][0] = true;
+    }
+    // Base case: with 0 elements, no positive sum can be achieved
+    for j in 1..=required_sum as usize {
+        dp[0][j] = false;
+    }
+    // Fill the DP table
+    for i in 1..=n {
+        for j in 1..=required_sum as usize {
+            if arr[i - 1] > j as i32 {
+                // Current element is too large, exclude it
+                dp[i][j] = dp[i - 1][j];
+            } else {
+                // Either exclude the current element or include it
+                dp[i][j] = dp[i - 1][j] || dp[i - 1][j - arr[i - 1] as usize];
+            }
+        }
+    }
+    dp[n][required_sum as usize]
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Macro to generate multiple test cases for the is_sum_subset function
+    macro_rules! subset_sum_tests {
+        ($($name:ident: $input:expr => $expected:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (arr, sum) = $input;
+                    assert_eq!(is_sum_subset(arr, sum), $expected);
+                }
+            )*
+        };
+    }
+    subset_sum_tests! {
+        // Common test cases
+        test_case_1: (&[2, 4, 6, 8], 5) => false,
+        test_case_2: (&[2, 4, 6, 8], 14) => true,
+        test_case_3: (&[3, 34, 4, 12, 5, 2], 9) => true,
+        test_case_4: (&[3, 34, 4, 12, 5, 2], 30) => false,
+        test_case_5: (&[1, 2, 3, 4, 5], 15) => true,
+
+        // Edge test cases
+        test_case_empty_array_positive_sum: (&[], 5) => false,
+        test_case_empty_array_zero_sum: (&[], 0) => true,
+        test_case_zero_sum: (&[1, 2, 3], 0) => true,
+        test_case_single_element_match: (&[5], 5) => true,
+        test_case_single_element_no_match: (&[3], 5) => false,
+    }
+}

--- a/__build4/unbounded_0_1_knapsack.cpp
+++ b/__build4/unbounded_0_1_knapsack.cpp
@@ -1,0 +1,173 @@
+/**
+ * @file
+ * @brief Implementation of the Unbounded 0/1 Knapsack Problem
+ *
+ * @details
+ * The Unbounded 0/1 Knapsack problem allows taking unlimited quantities of each
+ * item. The goal is to maximize the total value without exceeding the given
+ * knapsack capacity. Unlike the 0/1 knapsack, where each item can be taken only
+ * once, in this variation, any item can be picked any number of times as long
+ * as the total weight stays within the knapsack's capacity.
+ *
+ * Given a set of N items, each with a weight and a value, represented by the
+ * arrays `wt` and `val` respectively, and a knapsack with a weight limit W, the
+ * task is to fill the knapsack to maximize the total value.
+ *
+ * @note weight and value of items is greater than zero
+ *
+ * ### Algorithm
+ * The approach uses dynamic programming to build a solution iteratively.
+ * A 2D array is used for memoization to store intermediate results, allowing
+ * the function to avoid redundant calculations.
+ *
+ * @author [Sanskruti Yeole](https://github.com/yeolesanskruti)
+ * @see dynamic_programming/0_1_knapsack.cpp
+ */
+
+#include <cassert>   // For using assert function to validate test cases
+#include <cstdint>   // For fixed-width integer types like std::uint16_t
+#include <iostream>  // Standard input-output stream
+#include <vector>    // Standard library for using dynamic arrays (vectors)
+
+/**
+ * @namespace dynamic_programming
+ * @brief Namespace for dynamic programming algorithms
+ */
+namespace dynamic_programming {
+
+/**
+ * @namespace Knapsack
+ * @brief Implementation of unbounded 0-1 knapsack problem
+ */
+namespace unbounded_knapsack {
+
+/**
+ * @brief Recursive function to calculate the maximum value obtainable using
+ *        an unbounded knapsack approach.
+ *
+ * @param i Current index in the value and weight vectors.
+ * @param W Remaining capacity of the knapsack.
+ * @param val Vector of values corresponding to the items.
+ * @note "val" data type can be changed according to the size of the input.
+ * @param wt Vector of weights corresponding to the items.
+ * @note "wt" data type can be changed according to the size of the input.
+ * @param dp 2D vector for memoization to avoid redundant calculations.
+ * @return The maximum value that can be obtained for the given index and
+ * capacity.
+ */
+std::uint16_t KnapSackFilling(std::uint16_t i, std::uint16_t W,
+                              const std::vector<std::uint16_t>& val,
+                              const std::vector<std::uint16_t>& wt,
+                              std::vector<std::vector<int>>& dp) {
+    if (i == 0) {
+        if (wt[0] <= W) {
+            return (W / wt[0]) *
+                   val[0];  // Take as many of the first item as possible
+        } else {
+            return 0;  // Can't take the first item
+        }
+    }
+    if (dp[i][W] != -1)
+        return dp[i][W];  // Return result if available
+
+    int nottake =
+        KnapSackFilling(i - 1, W, val, wt, dp);  // Value without taking item i
+    int take = 0;
+    if (W >= wt[i]) {
+        take = val[i] + KnapSackFilling(i, W - wt[i], val, wt,
+                                        dp);  // Value taking item i
+    }
+    return dp[i][W] =
+               std::max(take, nottake);  // Store and return the maximum value
+}
+
+/**
+ * @brief Wrapper function to initiate the unbounded knapsack calculation.
+ *
+ * @param N Number of items.
+ * @param W Maximum weight capacity of the knapsack.
+ * @param val Vector of values corresponding to the items.
+ * @param wt Vector of weights corresponding to the items.
+ * @return The maximum value that can be obtained for the given capacity.
+ */
+std::uint16_t unboundedKnapsack(std::uint16_t N, std::uint16_t W,
+                                const std::vector<std::uint16_t>& val,
+                                const std::vector<std::uint16_t>& wt) {
+    if (N == 0)
+        return 0;  // Expect 0 since no items
+    std::vector<std::vector<int>> dp(
+        N, std::vector<int>(W + 1, -1));  // Initialize memoization table
+    return KnapSackFilling(N - 1, W, val, wt, dp);  // Start the calculation
+}
+
+}  // namespace unbounded_knapsack
+
+}  // namespace dynamic_programming
+
+/**
+ * @brief self test implementation
+ * @return void
+ */
+static void tests() {
+    // Test Case 1
+    std::uint16_t N1 = 4;                            // Number of items
+    std::vector<std::uint16_t> wt1 = {1, 3, 4, 5};   // Weights of the items
+    std::vector<std::uint16_t> val1 = {6, 1, 7, 7};  // Values of the items
+    std::uint16_t W1 = 8;  // Maximum capacity of the knapsack
+    // Test the function and assert the expected output
+    assert(dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+               N1, W1, val1, wt1) == 48);
+    std::cout << "Maximum Knapsack value "
+              << dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+                     N1, W1, val1, wt1)
+              << std::endl;
+
+    // Test Case 2
+    std::uint16_t N2 = 3;                              // Number of items
+    std::vector<std::uint16_t> wt2 = {10, 20, 30};     // Weights of the items
+    std::vector<std::uint16_t> val2 = {60, 100, 120};  // Values of the items
+    std::uint16_t W2 = 5;  // Maximum capacity of the knapsack
+    // Test the function and assert the expected output
+    assert(dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+               N2, W2, val2, wt2) == 0);
+    std::cout << "Maximum Knapsack value "
+              << dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+                     N2, W2, val2, wt2)
+              << std::endl;
+
+    // Test Case 3
+    std::uint16_t N3 = 3;                           // Number of items
+    std::vector<std::uint16_t> wt3 = {2, 4, 6};     // Weights of the items
+    std::vector<std::uint16_t> val3 = {5, 11, 13};  // Values of the items
+    std::uint16_t W3 = 27;  // Maximum capacity of the knapsack
+    // Test the function and assert the expected output
+    assert(dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+               N3, W3, val3, wt3) == 27);
+    std::cout << "Maximum Knapsack value "
+              << dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+                     N3, W3, val3, wt3)
+              << std::endl;
+
+    // Test Case 4
+    std::uint16_t N4 = 0;                  // Number of items
+    std::vector<std::uint16_t> wt4 = {};   // Weights of the items
+    std::vector<std::uint16_t> val4 = {};  // Values of the items
+    std::uint16_t W4 = 10;                 // Maximum capacity of the knapsack
+    assert(dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+               N4, W4, val4, wt4) == 0);
+    std::cout << "Maximum Knapsack value for empty arrays: "
+              << dynamic_programming::unbounded_knapsack::unboundedKnapsack(
+                     N4, W4, val4, wt4)
+              << std::endl;
+
+    std::cout << "All test cases passed!" << std::endl;
+}
+
+/**
+ * @brief main function
+ * @return 0 on successful exit
+ */
+int main() {
+    tests();  // Run self test implementation
+    return 0;
+}


### PR DESCRIPTION
76 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.